### PR TITLE
Add lifecycle migration examples from prod_status/ProdStatus tags

### DIFF
--- a/examples/17-lifecycle-from-tag.yaml
+++ b/examples/17-lifecycle-from-tag.yaml
@@ -1,0 +1,64 @@
+# Set Lifecycle State from prod_status / ProdStatus Tag
+#
+# Many customers track production status via a node tag named either
+# "prod_status" or "ProdStatus". This plan migrates that data to the
+# first-class lifecycleState attribute.
+#
+# The filter demonstrates matching multiple tag names AND multiple values
+# for the same logical state (e.g. "Preproduction" and "Pre-production"
+# are both common spellings). hasTag() is case-insensitive, so "prod" and
+# "Prod" are handled automatically.
+#
+# Run this plan BEFORE removing the tags so that alarm filters can be
+# updated between the two operations.
+#
+# Supported mappings (extend the or conditions as needed):
+#   production    <- prod_status/ProdStatus = "production" | "prod"
+#   preproduction <- prod_status/ProdStatus = "preproduction" | "pre-production" | "preprod"
+#
+# Usage:
+#   export TRUSTGRID_API_KEY_ID="your_key_id"
+#   export TRUSTGRID_API_KEY_SECRET="your_secret"
+#   jsoninator -plan=examples/17-lifecycle-from-tag.yaml -dryrun=false
+
+input:
+  http:
+    url: https://portal.trustgrid.io/node?projection[0]=uid&projection[1]=name&projection[2]=tags&projection[3]=lifecycleState
+    headers:
+      Authorization: "trustgrid-token ${TRUSTGRID_API_KEY_ID}:${TRUSTGRID_API_KEY_SECRET}"
+      Accept: application/json
+
+pipeline:
+  processors:
+    # Keep only nodes whose tag value maps to a known lifecycle state.
+    # Using `or` chains multiple hasTag() calls to match both tag names
+    # and spelling variants in a single expression.
+    - filter:
+        query: |
+          {{if or
+            (hasTag . "prod_status" "production") (hasTag . "prod_status" "prod")
+            (hasTag . "ProdStatus"  "production") (hasTag . "ProdStatus"  "prod")
+            (hasTag . "prod_status" "preproduction") (hasTag . "prod_status" "pre-production") (hasTag . "prod_status" "preprod")
+            (hasTag . "ProdStatus"  "preproduction") (hasTag . "ProdStatus"  "pre-production") (hasTag . "ProdStatus"  "preprod")
+          }}true{{else}}false{{end}}
+
+    # Skip nodes whose lifecycleState is already set to one of our target values
+    # so they don't generate spurious change records.
+    - filter:
+        query: |
+          {{if or (eq .lifecycleState "production") (eq .lifecycleState "preproduction")}}false{{else}}true{{end}}
+
+    # Derive the target lifecycleState from whichever tag value matched.
+    - replace:
+        template:
+          lifecycleState: |
+            {{if or (hasTag . "prod_status" "production") (hasTag . "prod_status" "prod") (hasTag . "ProdStatus" "production") (hasTag . "ProdStatus" "prod")}}production{{else}}preproduction{{end}}
+
+output:
+  http:
+    url: https://portal.trustgrid.io/v2/node/{{.uid}}/lifecycle-state
+    method: PUT
+    status_codes: [200]
+    headers:
+      Authorization: "trustgrid-token ${TRUSTGRID_API_KEY_ID}:${TRUSTGRID_API_KEY_SECRET}"
+      Content-Type: application/json

--- a/examples/18-remove-lifecycle-tags.yaml
+++ b/examples/18-remove-lifecycle-tags.yaml
@@ -1,0 +1,46 @@
+# Remove prod_status / ProdStatus Tag After Lifecycle Migration
+#
+# Once lifecycleState has been set (see 17-lifecycle-from-tag.yaml) and
+# alarm filters have been updated to use lifecycleState, use this plan to
+# clean up the legacy tag.
+#
+# Run this plan ONCE PER TAG NAME. Set LIFECYCLE_TAG_NAME to the tag you
+# want to remove, then run again for the other tag name if needed.
+#
+# Example:
+#   export TRUSTGRID_API_KEY_ID="your_key_id"
+#   export TRUSTGRID_API_KEY_SECRET="your_secret"
+#
+#   # Remove the "prod_status" tag
+#   LIFECYCLE_TAG_NAME=prod_status \
+#     jsoninator -plan=examples/18-remove-lifecycle-tags.yaml -dryrun=false
+#
+#   # Remove the "ProdStatus" tag
+#   LIFECYCLE_TAG_NAME=ProdStatus \
+#     jsoninator -plan=examples/18-remove-lifecycle-tags.yaml -dryrun=false
+
+input:
+  http:
+    url: https://portal.trustgrid.io/node?projection[0]=uid&projection[1]=name&projection[2]=tags&projection[3]=lifecycleState
+    headers:
+      Authorization: "trustgrid-token ${TRUSTGRID_API_KEY_ID}:${TRUSTGRID_API_KEY_SECRET}"
+      Accept: application/json
+
+pipeline:
+  processors:
+    # Keep only nodes that have lifecycleState set (migration complete)
+    # AND still carry the legacy tag we want to remove.
+    - filter:
+        query: |
+          {{if not .lifecycleState}}false{{else}}true{{end}}
+    - filter:
+        query: |
+          {{if isSet .tags "${LIFECYCLE_TAG_NAME}"}}true{{else}}false{{end}}
+
+output:
+  http:
+    url: https://portal.trustgrid.io/node/{{.uid}}/tag/${LIFECYCLE_TAG_NAME}
+    method: DELETE
+    status_codes: [200, 204]
+    headers:
+      Authorization: "trustgrid-token ${TRUSTGRID_API_KEY_ID}:${TRUSTGRID_API_KEY_SECRET}"

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,12 @@ Full ETL workflow: fetch from API, transform data, send to API.
 ### 16-lifecycle-update.yaml
 Shows how to set the lifecycleStatus on devices based on their prod_status tag, and uses the `hasTag` helper.
 
+### 17-lifecycle-from-tag.yaml
+Migrates `prod_status` / `ProdStatus` tags to the lifecycleState attribute, demonstrating how to match multiple tag names and spelling variants (e.g. "pre-production" vs "preproduction") with chained `or` / `hasTag` calls.
+
+### 18-remove-lifecycle-tags.yaml
+Removes the legacy `prod_status` or `ProdStatus` tag from nodes whose lifecycleState is already set. Run once per tag name via the `LIFECYCLE_TAG_NAME` environment variable. Execute this plan **after** updating alarm filters to use lifecycleState.
+
 ## Running Examples
 
 All examples can be run with:


### PR DESCRIPTION
## Summary

- Adds `17-lifecycle-from-tag.yaml`: sets `lifecycleState` from a `prod_status` or `ProdStatus` node tag, demonstrating how to match multiple tag names and spelling variants (`preproduction`, `pre-production`, `preprod`, etc.) using chained `or` / `hasTag` calls
- Adds `18-remove-lifecycle-tags.yaml`: removes the legacy tag after lifecycle migration; uses a `LIFECYCLE_TAG_NAME` env var so one plan covers both tag names without duplication
- Updates `examples/README.md` to document both new plans

Closes #9